### PR TITLE
Add minimal pycmaya package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # pycmaya
 
+`pycmaya` is a minimal example Python package that exposes a simple
+command line interface powered by the [maya](https://github.com/timofurrer/maya)
+library. Running the ``pycmaya`` command prints the current time in RFC 3339
+format.
+
+## Usage
+
+```bash
+pip install -e .
+pycmaya
+```

--- a/pycmaya/__init__.py
+++ b/pycmaya/__init__.py
@@ -1,0 +1,18 @@
+"""pycmaya module providing a simple datetime formatter using maya."""
+
+from __future__ import annotations
+
+import maya
+
+__all__ = ["__version__", "format_now"]
+__version__ = "0.1.0"
+
+def format_now() -> str:
+    """Return the current time in RFC 3339 format using ``maya``.
+
+    Returns
+    -------
+    str
+        Current time as RFC 3339 formatted string.
+    """
+    return maya.now().rfc3339()

--- a/pycmaya/__main__.py
+++ b/pycmaya/__main__.py
@@ -1,0 +1,14 @@
+"""Command line interface for pycmaya."""
+
+from __future__ import annotations
+
+from . import format_now
+
+
+def main() -> None:
+    """Entry point for the ``pycmaya`` command."""
+    print(format_now())
+
+
+if __name__ == "__main__":  # pragma: no cover - executed only when called directly
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pycmaya"
+version = "0.1.0"
+description = "Simple package demonstrating use of maya library"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Example", email = "example@example.com"}]
+dependencies = ["maya"]
+
+[project.scripts]
+pycmaya = "pycmaya.__main__:main"

--- a/tests/test_pycmaya.py
+++ b/tests/test_pycmaya.py
@@ -1,0 +1,7 @@
+from pycmaya import format_now
+
+
+def test_format_now():
+    result = format_now()
+    assert isinstance(result, str)
+    assert 'T' in result and result.endswith('Z')


### PR DESCRIPTION
## Summary
- implement simple `pycmaya` package using the `maya` datetime library
- add CLI entrypoint that prints the current time
- provide tests for `format_now`
- configure packaging with `pyproject.toml`
- document usage in `README`

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883014f94d8832b88197262f2a65e97